### PR TITLE
Allow to override build date

### DIFF
--- a/txt2tags.py
+++ b/txt2tags.py
@@ -3790,7 +3790,7 @@ class MacroMaster:
         self.config = config or CONF
         self.infile = self.config["sourcefile"]
         self.outfile = self.config["outfile"]
-        self.currdate = time.localtime(time.time())
+        self.currdate = time.gmtime(int(os.environ.get('SOURCE_DATE_EPOCH', time.time())))
         self.rgx = regex.get("macros") or getRegexes()["macros"]
         self.fileinfo = {"infile": None, "outfile": None}
         self.dft_fmt = MACROS
@@ -3863,7 +3863,7 @@ class MacroMaster:
                     fdate = self.currdate
                 else:
                     mtime = os.path.getmtime(self.infile)
-                    fdate = time.localtime(mtime)
+                    fdate = time.gmtime(mtime)
                 txt = time.strftime(fmt, fdate)
             elif name == "infile" or name == "outfile":
                 self.set_file_info(name)


### PR DESCRIPTION
Allow to override build date
with `SOURCE_DATE_EPOCH` and use UTC to be independent of timezone
to make build results reproducible.

See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

based on earlier
commit 49b080838451aa9f06bba9c957ef0f02808f5c2a
by Chris Lamb